### PR TITLE
Parse yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject",
     "electron": "electron .",
-    "dev": "nf start -p 3000"
+    "dev": "nf start -p 4327"
   },
   "devDependencies": {
     "electron": "^1.8.3",

--- a/public/mnist.yml
+++ b/public/mnist.yml
@@ -1,0 +1,37 @@
+---
+train:
+  data:
+    - mnist:
+        images:
+          url: "http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz"
+        labels:
+          url: "http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz"
+
+model:
+  - input: images
+
+  - convolution:
+      kernels: 64
+      size: [2, 2]
+  - activation: relu
+
+  - convolution:
+      kernels: 96
+      size: [2, 2]
+  - activation: relu
+
+  - pool: [3, 3]
+
+  - convolution:
+      kernels: 96
+      size: [2, 2]
+  - activation: relu
+
+  - flatten:
+  - dense: [64, 10]
+
+  - activation: softmax
+    name: labels
+        
+include: mnist-defaults.yml
+...

--- a/src/controller/KurConfigController.js
+++ b/src/controller/KurConfigController.js
@@ -14,17 +14,58 @@ export default class KurConfigController {
   parseFile(file){
     this.model = new KurConfigModel();
 
-    console.log(Object.keys(file));
     for(let i = 0; i < file.length; i++){
       let element = file[i];
-      console.log(element);
+        let layer = this.getLayer(element);
+        this.model.addLayer(layer);
+    }
+    console.log(this.model);
+  }
+
+  getLayer(element){
+    let layer = {};
+
+    if(element.hasOwnProperty('input')){
+      layer.type = "input";
+      layer.input = element["input"];
+    }
+    if(element.hasOwnProperty('convolution')){
+      layer.type = "convolution";
+      let components = element.convolution;
+      this.addLayerComponents(layer, components);
+    }else if(element.hasOwnProperty('activation')){
+      layer.type = "activation";
+      layer.activation = element.activation;
+
+      if(element.hasOwnProperty("name")){
+        layer.name = element["name"];
+      }
+    }else if(element.hasOwnProperty('pool')){
+      layer.type = "pool";
+      let components = element.pool;
+      this.addLayerComponents(layer, components);
+    }else if(element.hasOwnProperty('flatten')){
+      layer.type = "flatten";
+      let components = element.flatten;
+      this.addLayerComponents(layer, components);
+    }else if(element.hasOwnProperty('dense')){
+      layer.type = "dense";
+      let components = element.dense;
+      this.addLayerComponents(layer, components);
     }
 
+    return layer;
+  }
 
+  addLayerComponents(layer, element){
+    for(let property in element){
+      layer[property] = element[property];
+    }
   }
 
   getExample () {
-    let exampleModel = new KurConfigModel();
-    return exampleModel.example;
+    return "This is working";
   }
+
+
 }

--- a/src/controller/KurConfigController.js
+++ b/src/controller/KurConfigController.js
@@ -1,6 +1,28 @@
 import KurConfigModel from '../model/KurConfigModel'
+import yamljs from 'yamljs';
 
 export default class KurConfigController {
+  constructor() {
+    this.loadFile('./mnist.yml');
+  }
+
+  loadFile(filename){
+    const file = yamljs.load(filename);
+    this.parseFile(file.model);
+  }
+
+  parseFile(file){
+    this.model = new KurConfigModel();
+
+    console.log(Object.keys(file));
+    for(let i = 0; i < file.length; i++){
+      let element = file[i];
+      console.log(element);
+    }
+
+
+  }
+
   getExample () {
     let exampleModel = new KurConfigModel();
     return exampleModel.example;

--- a/src/electron-starter.js
+++ b/src/electron-starter.js
@@ -13,7 +13,7 @@ let mainWindow
 
 function createWindow () {
   // Create the browser window.
-  mainWindow = new BrowserWindow({width: 800, height: 600});
+  mainWindow = new BrowserWindow({width: 1920, height: 1080});
 
   // and load the index.html of the app
   const startUrl = process.env.ELECTRON_START_URL || url.format({

--- a/src/electron-wait-react.js
+++ b/src/electron-wait-react.js
@@ -1,5 +1,5 @@
 const net = require('net');
-const port = process.env.PORT ? (process.env.PORT - 100) : 3000;
+const port = process.env.PORT ? (process.env.PORT - 100) : 4327;
 
 process.env.ELECTRON_START_URL = `http://localhost:${port}`;
 

--- a/src/model/KurConfigModel.js
+++ b/src/model/KurConfigModel.js
@@ -1,3 +1,18 @@
 export default class KurConfigModel {
+  input = "";
+  layers = [];
+  activation = []
   example = "This is working.";
+
+  setInput(input){
+    this.input = input;
+  }
+
+  addLayer(layer){
+    this.layers.push(layer);
+  }
+
+  setActivation(activation){
+    this.activation = activation;
+  }
 }

--- a/src/model/KurConfigModel.js
+++ b/src/model/KurConfigModel.js
@@ -1,18 +1,7 @@
 export default class KurConfigModel {
-  input = "";
   layers = [];
-  activation = []
-  example = "This is working.";
-
-  setInput(input){
-    this.input = input;
-  }
 
   addLayer(layer){
     this.layers.push(layer);
-  }
-
-  setActivation(activation){
-    this.activation = activation;
   }
 }

--- a/src/view/components/Editor/TreeGraph.js
+++ b/src/view/components/Editor/TreeGraph.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import {SortableTreeWithoutDndContext as SortableTree, removeNodeAtPath,  toggleExpandedForAll} from 'react-sortable-tree';
 import 'react-sortable-tree/style.css'; // This only needs to be imported once in your app
-import FileExplorerTheme from 'react-sortable-tree-theme-full-node-drag';
 import {externalNodeType} from './NodetoDrag';
 import TitleExpansion from './TitleExpansion';
 
@@ -49,7 +48,6 @@ export default class Tree extends Component {
                 <SortableTree
                     treeData={this.state.treeData}
                     onChange={treeData => this.setState({treeData})}
-                    theme={FileExplorerTheme}
                     dndType={externalNodeType}
                     generateNodeProps={({ node, path }) => ({
                         buttons: [

--- a/src/view/components/Sidebar/FilePicker.js
+++ b/src/view/components/Sidebar/FilePicker.js
@@ -24,8 +24,10 @@ class FilePicker extends React.Component {
   handlePickFile = (e) => {
     if (e.target.files.length === 1) {
       this.setState({
-        file: e.target.files[0]
+        file: e.target.files[0].path
       });
+      let filePath = e.target.files[0].name;
+      this.props.controller.loadFile(filePath);
     }
   };
 

--- a/src/view/components/Sidebar/Sidebar.js
+++ b/src/view/components/Sidebar/Sidebar.js
@@ -23,8 +23,9 @@ const styles = theme => ({
 });
 
 class Sidebar extends React.Component {
+
   render() {
-    const { classes } = this.props;
+    const { classes, controller } = this.props;
 
     return (
       <div className={classes.root}>
@@ -41,7 +42,7 @@ class Sidebar extends React.Component {
               </Typography>
             </Toolbar>
           </AppBar>
-          <FilePicker/>
+          <FilePicker controller={controller}/>
         </Drawer>
       </div>
     )

--- a/src/view/containers/App.js
+++ b/src/view/containers/App.js
@@ -5,7 +5,6 @@ import KurConfigController from '../../controller/KurConfigController';
 import '../styles/App.css';
 import { DragDropContext } from 'react-dnd';
 import HTML5Backend from 'react-dnd-html5-backend';
-
 import Editor from "../components/Editor/Editor";
 
 
@@ -28,11 +27,15 @@ const theme = createMuiTheme({
 });
 
 class UnwrappedApp extends Component {
+    state = {
+      controller: undefined
+    };
+
     componentWillMount() {
-        let exampleController = new KurConfigController();
+        let controller = new KurConfigController();
 
         this.setState({
-            exampleController,
+            controller: controller,
         });
     }
 
@@ -40,9 +43,9 @@ class UnwrappedApp extends Component {
         return (
             <MuiThemeProvider theme={theme}>
                 <div className="App">
-                    <Sidebar/>
-                      <Editor/>
-                    </div>
+                    <Sidebar controller={this.state.controller}/>
+                    <Editor/>
+                </div>
             </MuiThemeProvider>
         );
     }


### PR DESCRIPTION
## What was added
1. Added the .yml parser for our internal representation. An example of the output is provided on the screenshot below
2. FilePicker integration, the parsed file is the one picked by the user

## How to Test
1. Open the app and the developer console
2. Click on Upload button
3. Pick a file
4. Watch the print on the console

## Notes for the reviewer
- I believe the file to be parsed must be on the /public folder of the project in order to be parsed. Might need a workaround.
- Changed the Elecron App resolution and the port where it works (for no reason)

## Screenshot
![captura de ecra de 2018-04-16 18-50-06](https://user-images.githubusercontent.com/12110089/38826210-0b400da2-41a7-11e8-9a31-3815ceb81d00.png)
